### PR TITLE
updated virtualizedCell.cellKey

### DIFF
--- a/src/components/SwiperFlatList/index.js
+++ b/src/components/SwiperFlatList/index.js
@@ -148,7 +148,7 @@ export default class SwiperFlatList extends PureComponent {
     setTimeout(() => this._scrollToIndex(info.index, false));
   };
 
-  _keyExtractor = (item, index) => index;
+  _keyExtractor = (item, index) => index.toString();
 
   renderChildren = ({ item }) => item;
 


### PR DESCRIPTION
updated virtualizedCell.cellKey to be a string instead of number

Should resolve this issue: https://github.com/gusgard/react-native-swiper-flatlist/issues/9