### PR TITLE
On momentum scroll end index

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "semicolons": true
 }

--- a/README.md
+++ b/README.md
@@ -88,24 +88,24 @@ const styles = StyleSheet.create({
 
 ## Props
 
-| Prop                   |                      Default                      |   Type   | Description                                           |
-| :--------------------- | :-----------------------------------------------: | :------: | :---------------------------------------------------- |
-| data                   |        _not required if children is used_         | `array`  | Data to use in renderItem                             |
-| children               |                         -                         |  `node`  | Children elements                                     |
-| renderItem             |        _not required if children is used_         |  `func`  | Takes an item from data and renders it into the list. |
-| onMomentumScrollEnd    |                         -                         |  `func`  | Called after scroll end, passes new index             |
-| vertical               |                       false                       |  `bool`  | Show vertical swiper                                  |
-| index                  |                         0                         | `number` | Index to start                                        |
-| renderAll              |                       false                       |  `bool`  | Render all the items before display it                |
+| Prop                   |                      Default                      |   Type   | Description                                                          |
+| :--------------------- | :-----------------------------------------------: | :------: | :------------------------------------------------------------------- |
+| data                   |        _not required if children is used_         | `array`  | Data to use in renderItem                                            |
+| children               |                         -                         |  `node`  | Children elements                                                    |
+| renderItem             |        _not required if children is used_         |  `func`  | Takes an item from data and renders it into the list.                |
+| onMomentumScrollEnd    |                         -                         |  `func`  | Called after scroll end and the first parameter is the current index |
+| vertical               |                       false                       |  `bool`  | Show vertical swiper                                                 |
+| index                  |                         0                         | `number` | Index to start                                                       |
+| renderAll              |                       false                       |  `bool`  | Render all the items before display it                               |
 | **Pagination**         |
-| showPagination         |                       false                       |  `bool`  | Show pagination                                       |
-| paginationDefaultColor |                       gray                        | `string` | Pagination color                                      |
-| paginationActiveColor  |                       white                       | `string` | Pagination color                                      |
-| PaginationComponent    | [Component](./src/components/Pagination/index.js) |  `node`  | Overwrite Pagination component                        |
+| showPagination         |                       false                       |  `bool`  | Show pagination                                                      |
+| paginationDefaultColor |                       gray                        | `string` | Pagination color                                                     |
+| paginationActiveColor  |                       white                       | `string` | Pagination color                                                     |
+| PaginationComponent    | [Component](./src/components/Pagination/index.js) |  `node`  | Overwrite Pagination component                                       |
 | **Autoplay**           |
-| autoplay               |                       false                       |  `bool`  | Change index automatically                            |
-| autoplayDelay          |                         3                         | `number` | Delay between every page                              |
-| autoplayLoop           |                       false                       |  `bool`  | Continue playing after reach end                      |
+| autoplay               |                       false                       |  `bool`  | Change index automatically                                           |
+| autoplayDelay          |                         3                         | `number` | Delay between every page                                             |
+| autoplayLoop           |                       false                       |  `bool`  | Continue playing after reach end                                     |
 
 <!--
 autoplayDirection: PropTypes.bool.isRequired,  -->

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const styles = StyleSheet.create({
 | :--------------------- | :-----------------------------------------------: | :------: | :------------------------------------------------------------------- |
 | data                   |        _not required if children is used_         | `array`  | Data to use in renderItem                                            |
 | children               |                         -                         |  `node`  | Children elements                                                    |
-| renderItem             |        _not required if children is used_         |  `func`  | Takes an item from data and renders it into the list.                |
+| renderItem             |        _not required if children is used_         |  `func`  | Takes an item from data and renders it into the list                 |
 | onMomentumScrollEnd    |                         -                         |  `func`  | Called after scroll end and the first parameter is the current index |
 | vertical               |                       false                       |  `bool`  | Show vertical swiper                                                 |
 | index                  |                         0                         | `number` | Index to start                                                       |

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
 | data                   |        _not required if children is used_         | `array`  | Data to use in renderItem                             |
 | children               |                         -                         |  `node`  | Children elements                                     |
 | renderItem             |        _not required if children is used_         |  `func`  | Takes an item from data and renders it into the list. |
-| onMomentumScrollEnd    |                         -                         |  `func`  | Called after scroll end                               |
+| onMomentumScrollEnd    |                         -                         |  `func`  | Called after scroll end, passes new index             |
 | vertical               |                       false                       |  `bool`  | Show vertical swiper                                  |
 | index                  |                         0                         | `number` | Index to start                                        |
 | renderAll              |                       false                       |  `bool`  | Render all the items before display it                |

--- a/src/components/SwiperFlatList/index.js
+++ b/src/components/SwiperFlatList/index.js
@@ -140,7 +140,7 @@ export default class SwiperFlatList extends PureComponent {
     this.setState({ paginationIndex: index });
 
     if (onMomentumScrollEnd) {
-      onMomentumScrollEnd();
+      onMomentumScrollEnd(index);
     }
   };
 

--- a/src/components/SwiperFlatList/index.js
+++ b/src/components/SwiperFlatList/index.js
@@ -140,7 +140,7 @@ export default class SwiperFlatList extends PureComponent {
     this.setState({ paginationIndex: index });
 
     if (onMomentumScrollEnd) {
-      onMomentumScrollEnd(index);
+      onMomentumScrollEnd({ index }, e);
     }
   };
 
@@ -167,12 +167,12 @@ export default class SwiperFlatList extends PureComponent {
       ref: component => {
         this.flatListRef = component;
       },
-      ...props,
       keyExtractor: this._keyExtractor,
       horizontal: !vertical,
       showsHorizontalScrollIndicator: false,
       showsVerticalScrollIndicator: false,
       pagingEnabled: true,
+      ...props,
       onMomentumScrollEnd: this._onMomentumScrollEnd,
       onScrollToIndexFailed: this._onScrollToIndexFailed,
       data: this._data,

--- a/src/components/SwiperFlatList/index.js
+++ b/src/components/SwiperFlatList/index.js
@@ -167,6 +167,7 @@ export default class SwiperFlatList extends PureComponent {
       ref: component => {
         this.flatListRef = component;
       },
+      ...props,
       keyExtractor: this._keyExtractor,
       horizontal: !vertical,
       showsHorizontalScrollIndicator: false,
@@ -174,7 +175,6 @@ export default class SwiperFlatList extends PureComponent {
       pagingEnabled: true,
       onMomentumScrollEnd: this._onMomentumScrollEnd,
       onScrollToIndexFailed: this._onScrollToIndexFailed,
-      ...props,
       data: this._data,
       renderItem: this._renderItem,
       initialNumToRender: this._initialNumToRender


### PR DESCRIPTION
`this._onMomentumScrollEnd` now calls the `onMomentumScrollEnd` props function with an index param.

This is the new index that the person has swiped to.

Additionally cleaned a bug where `flatListProps` had the `onMomentumScrollEnd` field overwritten by `...props`, resulting in the function never even being called!

Added semicolons to the prettierrc, because my default is none:)