### PR TITLE
update pagination index on ComponentUpdate

### DIFF
--- a/src/components/SwiperFlatList/index.js
+++ b/src/components/SwiperFlatList/index.js
@@ -69,6 +69,9 @@ export default class SwiperFlatList extends PureComponent {
 
   componentWillUpdate(nextProps) {
     this.setup(nextProps);
+  }
+
+  componentWillReceiveProps (nextProps) {
     this.setState({ paginationIndex: nextProps.index });
   }
 

--- a/src/components/SwiperFlatList/index.js
+++ b/src/components/SwiperFlatList/index.js
@@ -71,7 +71,7 @@ export default class SwiperFlatList extends PureComponent {
     this.setup(nextProps);
   }
 
-  componentWillReceiveProps (nextProps) {
+  componentWillReceiveProps(nextProps) {
     this.setState({ paginationIndex: nextProps.index });
   }
 

--- a/src/components/SwiperFlatList/index.js
+++ b/src/components/SwiperFlatList/index.js
@@ -69,6 +69,7 @@ export default class SwiperFlatList extends PureComponent {
 
   componentWillUpdate(nextProps) {
     this.setup(nextProps);
+    this.setState({ paginationIndex: nextProps.index });
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Pagination index is ignored when component is updated. This is a simple fix that updates state on `componentWillReceiveProps()`