### PR TITLE
Replaced Math.floor with Math.round

### DIFF
--- a/src/components/SwiperFlatList/index.js
+++ b/src/components/SwiperFlatList/index.js
@@ -130,10 +130,10 @@ export default class SwiperFlatList extends PureComponent {
     const { contentOffset, layoutMeasurement } = e.nativeEvent;
     let index;
     if (vertical) {
-      index = Math.floor(contentOffset.y / layoutMeasurement.height);
+      index = Math.round(contentOffset.y / layoutMeasurement.height);
     } else {
       // Divide the horizontal offset by the width of the view to see which page is visible
-      index = Math.floor(contentOffset.x / layoutMeasurement.width);
+      index = Math.round(contentOffset.x / layoutMeasurement.width);
     }
 
     if (autoplay) {


### PR DESCRIPTION
Sometimes the selected index that is returned by 'onMomentumScrollEnd' callback is wrong. Solution proposed by AsimPoptani in the Issue #36 seems to work fine.