### PR TITLE
Fix for Issue where onChangeIndex is called with old indexes

### DIFF
--- a/src/components/SwiperFlatList/SwiperFlatList.js
+++ b/src/components/SwiperFlatList/SwiperFlatList.js
@@ -105,6 +105,11 @@ const SwiperFlatList = React.forwardRef(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [paginationIndexes]);
 
+
+    React.useEffect(() => {
+      _onChangeIndex({ index: paginationIndex, prevIndex: prevIndex });
+    },[paginationIndex,prevIndex]);
+
     React.useImperativeHandle(ref, () => ({
       scrollToIndex: (...args) => {
         setScrollEnabled(true);
@@ -157,7 +162,7 @@ const SwiperFlatList = React.forwardRef(
 
       onMomentumScrollEnd?.({ index: paginationIndex }, e);
 
-      _onChangeIndex({ index: paginationIndex, prevIndex });
+      //_onChangeIndex({ index: paginationIndex, prevIndex });
     };
 
     const _onViewableItemsChanged = React.useMemo(


### PR DESCRIPTION
Fix for issue #55:
OnChangeIndex was called on the "onMomentumScrollEnd" event of the flatlist which sometimes was called before indexes are updated. Now calling OnChangeIndex as a side effect in useEffect whenever indexes are changed. 
