### PR TITLE
Added `autoplayLoopAnimation` and `onPaginationIndexSelected` props

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ const styles = StyleSheet.create({
 | autoplay                |                       false                       |        `bool`         | Change index automatically                                           |
 | autoplayDelay           |                         3                         |       `number`        | Delay between every page in seconds                                  |
 | autoplayLoop            |                       false                       |        `bool`         | Continue playing after reach end                                     |
-| autoplayInvertDirection |                       false                       |        `bool`         | Invert auto play direction        
-| disableGesture |                       false                       |        `bool`         | Disable swipe gesture                                          |
+| autoplayLoopAnimation   |                       false                       |        `bool`         | Enable loop animation                                                |
+| autoplayInvertDirection |                       false                       |        `bool`         | Invert auto play direction                                           |
+| disableGesture          |                       false                       |        `bool`         | Disable swipe gesture                                                |
 
 **More props**
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ or
 npm install react-native-swiper-flatlist --save
 ```
 
-
-## Notice 
+## Notice
 
 Version 2.x was re-implemented using React Hooks so it only works with version 0.59 or above
 
@@ -48,13 +47,7 @@ export default class App extends PureComponent {
   render() {
     return (
       <View style={styles.container}>
-        <SwiperFlatList
-          autoplay
-          autoplayDelay={2}
-          autoplayLoop
-          index={2}
-          showPagination
-        >
+        <SwiperFlatList autoplay autoplayDelay={2} autoplayLoop index={2} showPagination>
           <View style={[styles.child, { backgroundColor: 'tomato' }]}>
             <Text style={styles.text}>1</Text>
           </View>
@@ -78,54 +71,52 @@ export const { width, height } = Dimensions.get('window');
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: 'white'
+    backgroundColor: 'white',
   },
   child: {
     height: height * 0.5,
     width,
-    justifyContent: 'center'
+    justifyContent: 'center',
   },
   text: {
     fontSize: width * 0.5,
-    textAlign: 'center'
-  }
+    textAlign: 'center',
+  },
 });
 ```
 
 [Code example](./example/README.md)
 
-
 ## Props
 
-| Prop                    |                      Default                      |         Type          | Description                                                          |
-| :---------------------- | :-----------------------------------------------: | :-------------------: | :------------------------------------------------------------------- |
-| data                    |        _not required if children is used_         |        `array`        | Data to use in renderItem                                            |
-| children                |                         -                         |        `node`         | Children elements                                                    |
-| renderItem              |        _not required if children is used_         |        `func`         | Takes an item from data and renders it into the list                 |
-| onMomentumScrollEnd     |                         -                         |        `func`         | Called after scroll end and the first parameter is the current index |
-| vertical                |                       false                       |        `bool`         | Show vertical swiper                                                 |
-| index                   |                         0                         |       `number`        | Index to start                                                       |
-| renderAll               |                       false                       |        `bool`         | Render all the items before display it                               |
-| **Pagination**          |
-| showPagination          |                       false                       |        `bool`         | Show pagination                                                      |
-| paginationDefaultColor  |                       gray                        |       `string`        | Pagination color                                                     |
-| paginationActiveColor   |                       white                       |       `string`        | Pagination color                                                     |
-| paginationStyle         |                        {}                         | `ViewPropTypes.style` | Style object for container                                           |
-| paginationStyleItem     |                        {}                         | `ViewPropTypes.style` | Style object for item (dot)                                          |
-| onPaginationPressed     |                         -                         |        `func`         | Called after scroll to new index when pagination item pressed        |
-| PaginationComponent     | [Component](./src/components/Pagination/index.js) |        `node`         | Overwrite Pagination component                                       |
-| **Autoplay**            |
-| autoplay                |                       false                       |        `bool`         | Change index automatically                                           |
-| autoplayDelay           |                         3                         |       `number`        | Delay between every page in seconds                                  |
-| autoplayLoop            |                       false                       |        `bool`         | Continue playing after reach end                                     |
-| autoplayLoopAnimation   |                       false                       |        `bool`         | Enable loop animation                                                |
-| autoplayInvertDirection |                       false                       |        `bool`         | Invert auto play direction                                           |
-| disableGesture          |                       false                       |        `bool`         | Disable swipe gesture                                                |
+| Prop                      |                      Default                      |         Type          | Description                                                          |
+| :------------------------ | :-----------------------------------------------: | :-------------------: | :------------------------------------------------------------------- |
+| data                      |        _not required if children is used_         |        `array`        | Data to use in renderItem                                            |
+| children                  |                         -                         |        `node`         | Children elements                                                    |
+| renderItem                |        _not required if children is used_         |        `func`         | Takes an item from data and renders it into the list                 |
+| onMomentumScrollEnd       |                         -                         |        `func`         | Called after scroll end and the first parameter is the current index |
+| vertical                  |                       false                       |        `bool`         | Show vertical swiper                                                 |
+| index                     |                         0                         |       `number`        | Index to start                                                       |
+| renderAll                 |                       false                       |        `bool`         | Render all the items before display it                               |
+| **Pagination**            |
+| showPagination            |                       false                       |        `bool`         | Show pagination                                                      |
+| paginationDefaultColor    |                       gray                        |       `string`        | Pagination color                                                     |
+| paginationActiveColor     |                       white                       |       `string`        | Pagination color                                                     |
+| paginationStyle           |                        {}                         | `ViewPropTypes.style` | Style object for container                                           |
+| paginationStyleItem       |                        {}                         | `ViewPropTypes.style` | Style object for item (dot)                                          |
+| onPaginationIndexSelected |                         -                         |        `func`         | Called after scroll to item when pagination index selected           |
+| PaginationComponent       | [Component](./src/components/Pagination/index.js) |        `node`         | Overwrite Pagination component                                       |
+| **Autoplay**              |
+| autoplay                  |                       false                       |        `bool`         | Change index automatically                                           |
+| autoplayDelay             |                         3                         |       `number`        | Delay between every page in seconds                                  |
+| autoplayLoop              |                       false                       |        `bool`         | Continue playing after reach end                                     |
+| autoplayLoopAnimation     |                       false                       |        `bool`         | Enable loop animation                                                |
+| autoplayInvertDirection   |                       false                       |        `bool`         | Invert auto play direction                                           |
+| disableGesture            |                       false                       |        `bool`         | Disable swipe gesture                                                |
 
 **More props**
 
 This is a wrapper around [Flatlist](http://facebook.github.io/react-native/docs/flatlist.html#props), all their `props` works well and the inherited `props` too (from [ScrollView](http://facebook.github.io/react-native/docs/scrollview#props) and [VirtualizedList](http://facebook.github.io/react-native/docs/virtualizedlist#props))
-
 
 ## Functions
 
@@ -138,12 +129,10 @@ This is a wrapper around [Flatlist](http://facebook.github.io/react-native/docs/
 | goToFirstIndex  | -                                       | Go to the first index                                                                               |
 | goToLastIndex   | -                                       | Go to the last index                                                                                |
 
-
-
 ## Limitations
 
-* Vertical pagination is not supported on Android. [Doc](https://github.com/facebook/react-native/blob/a48da14800013659e115bf2b58e31aa396e678e5/Libraries/Components/ScrollView/ScrollView.js#L274)
-* `react-native-web` is not supported, due to the lack of support of some `props` used in this library. [Expo example](https://snack.expo.io/@gusgard/react-native-web-example-with-swiper)
+- Vertical pagination is not supported on Android. [Doc](https://github.com/facebook/react-native/blob/a48da14800013659e115bf2b58e31aa396e678e5/Libraries/Components/ScrollView/ScrollView.js#L274)
+- `react-native-web` is not supported, due to the lack of support of some `props` used in this library. [Expo example](https://snack.expo.io/@gusgard/react-native-web-example-with-swiper)
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ const styles = StyleSheet.create({
 | paginationActiveColor   |                       white                       |       `string`        | Pagination color                                                     |
 | paginationStyle         |                        {}                         | `ViewPropTypes.style` | Style object for container                                           |
 | paginationStyleItem     |                        {}                         | `ViewPropTypes.style` | Style object for item (dot)                                          |
+| onPaginationPressed     |                         -                         |        `func`         | Called after scroll to new index when pagination item pressed        |
 | PaginationComponent     | [Component](./src/components/Pagination/index.js) |        `node`         | Overwrite Pagination component                                       |
 | **Autoplay**            |
 | autoplay                |                       false                       |        `bool`         | Change index automatically                                           |

--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ const styles = StyleSheet.create({
 | paginationActiveColor     |                       white                       |       `string`        | Pagination color                                                     |
 | paginationStyle           |                        {}                         | `ViewPropTypes.style` | Style object for container                                           |
 | paginationStyleItem       |                        {}                         | `ViewPropTypes.style` | Style object for item (dot)                                          |
-| onPaginationIndexSelected |                         -                         |        `func`         | Called after scroll to item when pagination index selected           |
+| onPaginationSelectedIndex |                         -                         |        `func`         | Executed when the user presses the pagination index, similar properties onChangeIndex  |
 | PaginationComponent       | [Component](./src/components/Pagination/index.js) |        `node`         | Overwrite Pagination component                                       |
 | **Autoplay**              |
 | autoplay                  |                       false                       |        `bool`         | Change index automatically                                           |
 | autoplayDelay             |                         3                         |       `number`        | Delay between every page in seconds                                  |
 | autoplayLoop              |                       false                       |        `bool`         | Continue playing after reach end                                     |
-| autoplayLoopAnimation     |                       false                       |        `bool`         | Enable loop animation                                                |
+| autoplayLoopKeepAnimation |                       false                       |        `bool`         | Show animation when reach the end of the list                        |
 | autoplayInvertDirection   |                       false                       |        `bool`         | Invert auto play direction                                           |
 | disableGesture            |                       false                       |        `bool`         | Disable swipe gesture                                                |
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ or
 npm install react-native-swiper-flatlist --save
 ```
 
-## Notice
+
+## Notice 
 
 Version 2.x was re-implemented using React Hooks so it only works with version 0.59 or above
 
@@ -47,7 +48,13 @@ export default class App extends PureComponent {
   render() {
     return (
       <View style={styles.container}>
-        <SwiperFlatList autoplay autoplayDelay={2} autoplayLoop index={2} showPagination>
+        <SwiperFlatList
+          autoplay
+          autoplayDelay={2}
+          autoplayLoop
+          index={2}
+          showPagination
+        >
           <View style={[styles.child, { backgroundColor: 'tomato' }]}>
             <Text style={styles.text}>1</Text>
           </View>
@@ -71,21 +78,22 @@ export const { width, height } = Dimensions.get('window');
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: 'white',
+    backgroundColor: 'white'
   },
   child: {
     height: height * 0.5,
     width,
-    justifyContent: 'center',
+    justifyContent: 'center'
   },
   text: {
     fontSize: width * 0.5,
-    textAlign: 'center',
-  },
+    textAlign: 'center'
+  }
 });
 ```
 
 [Code example](./example/README.md)
+
 
 ## Props
 
@@ -118,6 +126,7 @@ const styles = StyleSheet.create({
 
 This is a wrapper around [Flatlist](http://facebook.github.io/react-native/docs/flatlist.html#props), all their `props` works well and the inherited `props` too (from [ScrollView](http://facebook.github.io/react-native/docs/scrollview#props) and [VirtualizedList](http://facebook.github.io/react-native/docs/virtualizedlist#props))
 
+
 ## Functions
 
 | Name            | Params                                  | Use                                                                                                 |
@@ -129,10 +138,12 @@ This is a wrapper around [Flatlist](http://facebook.github.io/react-native/docs/
 | goToFirstIndex  | -                                       | Go to the first index                                                                               |
 | goToLastIndex   | -                                       | Go to the last index                                                                                |
 
+
+
 ## Limitations
 
-- Vertical pagination is not supported on Android. [Doc](https://github.com/facebook/react-native/blob/a48da14800013659e115bf2b58e31aa396e678e5/Libraries/Components/ScrollView/ScrollView.js#L274)
-- `react-native-web` is not supported, due to the lack of support of some `props` used in this library. [Expo example](https://snack.expo.io/@gusgard/react-native-web-example-with-swiper)
+* Vertical pagination is not supported on Android. [Doc](https://github.com/facebook/react-native/blob/a48da14800013659e115bf2b58e31aa396e678e5/Libraries/Components/ScrollView/ScrollView.js#L274)
+* `react-native-web` is not supported, due to the lack of support of some `props` used in this library. [Expo example](https://snack.expo.io/@gusgard/react-native-web-example-with-swiper)
 
 ## Author
 

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -29,7 +29,7 @@ const Pagination = ({
   paginationActiveColor,
   paginationStyle,
   paginationStyleItem,
-  onPaginationPressed,
+  onPaginationIndexSelected,
 }) => {
   return (
     <View style={[styles.container, paginationStyle]}>
@@ -45,7 +45,7 @@ const Pagination = ({
           key={index}
           onPress={() => {
             scrollToIndex({ index });
-            onPaginationPressed?.();
+            onPaginationIndexSelected?.();
           }}
         />
       ))}
@@ -60,7 +60,7 @@ Pagination.propTypes = {
   paginationDefaultColor: PropTypes.string,
   paginationStyle: ViewPropTypes.style,
   paginationStyleItem: ViewPropTypes.style,
-  onPaginationPressed: PropTypes.func,
+  onPaginationIndexSelected: PropTypes.func,
 };
 
 Pagination.defaultProps = {
@@ -69,7 +69,7 @@ Pagination.defaultProps = {
   paginationDefaultColor: colors.gray,
   paginationStyle: {},
   paginationStyleItem: {},
-  onPaginationPressed: undefined,
+  onPaginationIndexSelected: undefined,
 };
 
 export default Pagination;

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -29,7 +29,7 @@ const Pagination = ({
   paginationActiveColor,
   paginationStyle,
   paginationStyleItem,
-  onPaginationIndexSelected,
+  onPaginationSelectedIndex,
 }) => {
   return (
     <View style={[styles.container, paginationStyle]}>
@@ -45,7 +45,7 @@ const Pagination = ({
           key={index}
           onPress={() => {
             scrollToIndex({ index });
-            onPaginationIndexSelected?.();
+            onPaginationSelectedIndex?.();
           }}
         />
       ))}
@@ -60,7 +60,7 @@ Pagination.propTypes = {
   paginationDefaultColor: PropTypes.string,
   paginationStyle: ViewPropTypes.style,
   paginationStyleItem: ViewPropTypes.style,
-  onPaginationIndexSelected: PropTypes.func,
+  onPaginationSelectedIndex: PropTypes.func,
 };
 
 Pagination.defaultProps = {
@@ -69,7 +69,7 @@ Pagination.defaultProps = {
   paginationDefaultColor: colors.gray,
   paginationStyle: {},
   paginationStyleItem: {},
-  onPaginationIndexSelected: undefined,
+  onPaginationSelectedIndex: undefined,
 };
 
 export default Pagination;

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -45,7 +45,7 @@ const Pagination = ({
           key={index}
           onPress={() => {
             scrollToIndex({ index });
-            onPaginationPressed();
+            onPaginationPressed?.();
           }}
         />
       ))}

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -29,6 +29,7 @@ const Pagination = ({
   paginationActiveColor,
   paginationStyle,
   paginationStyleItem,
+  onPaginationPressed,
 }) => {
   return (
     <View style={[styles.container, paginationStyle]}>
@@ -42,7 +43,10 @@ const Pagination = ({
               : { backgroundColor: paginationDefaultColor },
           ]}
           key={index}
-          onPress={() => scrollToIndex({ index })}
+          onPress={() => {
+            scrollToIndex({ index });
+            onPaginationPressed();
+          }}
         />
       ))}
     </View>
@@ -56,6 +60,7 @@ Pagination.propTypes = {
   paginationDefaultColor: PropTypes.string,
   paginationStyle: ViewPropTypes.style,
   paginationStyleItem: ViewPropTypes.style,
+  onPaginationPressed: PropTypes.func,
 };
 
 Pagination.defaultProps = {
@@ -64,6 +69,7 @@ Pagination.defaultProps = {
   paginationDefaultColor: colors.gray,
   paginationStyle: {},
   paginationStyleItem: {},
+  onPaginationPressed: undefined,
 };
 
 export default Pagination;

--- a/src/components/SwiperFlatList/SwiperFlatList.js
+++ b/src/components/SwiperFlatList/SwiperFlatList.js
@@ -146,9 +146,7 @@ const SwiperFlatList = React.forwardRef(
           }
 
           // Disable end loop animation unless `autoplayLoopAnimation` prop configured
-          let animate = !isLastIndexEnd 
-            ? true 
-            : autoplayLoopAnimation;
+          let animate = !isLastIndexEnd ? true : autoplayLoopAnimation;
 
           _scrollToIndex({ index: nextIndex, animated: animate });
         }, autoplayDelay * MILLISECONDS);

--- a/src/components/SwiperFlatList/SwiperFlatList.js
+++ b/src/components/SwiperFlatList/SwiperFlatList.js
@@ -24,7 +24,7 @@ const SwiperFlatList = React.forwardRef(
       paginationDefaultColor,
       paginationStyle,
       paginationStyleItem,
-      onPaginationPressed,
+      onPaginationIndexSelected,
       // Autoplay
       autoplayDelay,
       autoplay,
@@ -219,7 +219,7 @@ const SwiperFlatList = React.forwardRef(
       paginationDefaultColor,
       paginationStyle,
       paginationStyleItem,
-      onPaginationPressed,
+      onPaginationIndexSelected,
     };
 
     return (
@@ -257,7 +257,7 @@ SwiperFlatList.propTypes = {
   paginationDefaultColor: Pagination.propTypes.paginationDefaultColor,
   paginationStyle: Pagination.propTypes.paginationStyle,
   paginationStyleItem: Pagination.propTypes.paginationStyleItem,
-  onPaginationPressed: Pagination.propTypes.onPaginationPressed,
+  onPaginationIndexSelected: Pagination.propTypes.onPaginationIndexSelected,
 
   // Autoplay
   autoplayDelay: PropTypes.number,

--- a/src/components/SwiperFlatList/SwiperFlatList.js
+++ b/src/components/SwiperFlatList/SwiperFlatList.js
@@ -24,12 +24,12 @@ const SwiperFlatList = React.forwardRef(
       paginationDefaultColor,
       paginationStyle,
       paginationStyleItem,
-      onPaginationIndexSelected,
+      onPaginationSelectedIndex,
       // Autoplay
       autoplayDelay,
       autoplay,
       autoplayLoop,
-      autoplayLoopAnimation,
+      autoplayLoopKeepAnimation,
       autoplayInvertDirection,
       // Functions
       onChangeIndex,
@@ -146,8 +146,8 @@ const SwiperFlatList = React.forwardRef(
             nextIndex = _data.length - 1;
           }
 
-          // Disable end loop animation unless `autoplayLoopAnimation` prop configured
-          let animate = !isLastIndexEnd ? true : autoplayLoopAnimation;
+          // Disable end loop animation unless `autoplayLoopKeepAnimation` prop configured
+          const animate = !isLastIndexEnd || autoplayLoopKeepAnimation;
 
           _scrollToIndex({ index: nextIndex, animated: animate });
         }, autoplayDelay * MILLISECONDS);
@@ -219,7 +219,7 @@ const SwiperFlatList = React.forwardRef(
       paginationDefaultColor,
       paginationStyle,
       paginationStyleItem,
-      onPaginationIndexSelected,
+      onPaginationSelectedIndex,
     };
 
     return (
@@ -257,14 +257,14 @@ SwiperFlatList.propTypes = {
   paginationDefaultColor: Pagination.propTypes.paginationDefaultColor,
   paginationStyle: Pagination.propTypes.paginationStyle,
   paginationStyleItem: Pagination.propTypes.paginationStyleItem,
-  onPaginationIndexSelected: Pagination.propTypes.onPaginationIndexSelected,
+  onPaginationSelectedIndex: Pagination.propTypes.onPaginationSelectedIndex,
 
   // Autoplay
   autoplayDelay: PropTypes.number,
   autoplay: PropTypes.bool,
   autoplayInvertDirection: PropTypes.bool,
   autoplayLoop: PropTypes.bool,
-  autoplayLoopAnimation: PropTypes.bool,
+  autoplayLoopKeepAnimation: PropTypes.bool,
 
   // Optionals
   onMomentumScrollEnd: PropTypes.func,
@@ -279,7 +279,7 @@ SwiperFlatList.defaultProps = {
   autoplayDelay: 3,
   autoplayInvertDirection: false,
   autoplayLoop: false,
-  autoplayLoopAnimation: false,
+  autoplayLoopKeepAnimation: false,
   autoplay: false,
   showPagination: false,
   vertical: false,

--- a/src/components/SwiperFlatList/SwiperFlatList.js
+++ b/src/components/SwiperFlatList/SwiperFlatList.js
@@ -28,6 +28,7 @@ const SwiperFlatList = React.forwardRef(
       autoplayDelay,
       autoplay,
       autoplayLoop,
+      autoplayLoopAnimation,
       autoplayInvertDirection,
       // Functions
       onChangeIndex,
@@ -144,8 +145,12 @@ const SwiperFlatList = React.forwardRef(
             nextIndex = _data.length - 1;
           }
 
-          // When reach the end disable animated
-          _scrollToIndex({ index: nextIndex, animated: !isLastIndexEnd });
+          // Disable end loop animation unless `autoplayLoopAnimation` prop configured
+          let animate = !isLastIndexEnd 
+            ? true 
+            : autoplayLoopAnimation;
+
+          _scrollToIndex({ index: nextIndex, animated: animate });
         }, autoplayDelay * MILLISECONDS);
       }
       // https://upmostly.com/tutorials/settimeout-in-react-components-using-hooks
@@ -258,6 +263,7 @@ SwiperFlatList.propTypes = {
   autoplay: PropTypes.bool,
   autoplayInvertDirection: PropTypes.bool,
   autoplayLoop: PropTypes.bool,
+  autoplayLoopAnimation: PropTypes.bool,
 
   // Optionals
   onMomentumScrollEnd: PropTypes.func,
@@ -272,6 +278,7 @@ SwiperFlatList.defaultProps = {
   autoplayDelay: 3,
   autoplayInvertDirection: false,
   autoplayLoop: false,
+  autoplayLoopAnimation: false,
   autoplay: false,
   showPagination: false,
   vertical: false,

--- a/src/components/SwiperFlatList/SwiperFlatList.js
+++ b/src/components/SwiperFlatList/SwiperFlatList.js
@@ -24,6 +24,7 @@ const SwiperFlatList = React.forwardRef(
       paginationDefaultColor,
       paginationStyle,
       paginationStyleItem,
+      onPaginationPressed,
       // Autoplay
       autoplayDelay,
       autoplay,
@@ -218,6 +219,7 @@ const SwiperFlatList = React.forwardRef(
       paginationDefaultColor,
       paginationStyle,
       paginationStyleItem,
+      onPaginationPressed,
     };
 
     return (
@@ -255,6 +257,7 @@ SwiperFlatList.propTypes = {
   paginationDefaultColor: Pagination.propTypes.paginationDefaultColor,
   paginationStyle: Pagination.propTypes.paginationStyle,
   paginationStyleItem: Pagination.propTypes.paginationStyleItem,
+  onPaginationPressed: Pagination.propTypes.onPaginationPressed,
 
   // Autoplay
   autoplayDelay: PropTypes.number,


### PR DESCRIPTION
- Added `autoplayLoopAnimation` prop to configure autoplay loop animation when end reached.
  - By default this value is set to `false` so original functionality remains (no animation when looping). 
  - Setting prop to true will enable scroll animation when looping.
- Added `onPaginationIndexSelected` prop to provide callback function when pagination item pressed