### PR TITLE
Fixes/guard against nan

### DIFF
--- a/src/components/SwiperFlatList/SwiperFlatList.js
+++ b/src/components/SwiperFlatList/SwiperFlatList.js
@@ -139,6 +139,11 @@ const SwiperFlatList = React.forwardRef(
       let autoplayTimer;
       if (shouldContinuoWithAutoplay || autoplayLoop) {
         autoplayTimer = setTimeout(() => {
+          if (_data.length < 1) {
+            // avoid nextIndex being set to NaN
+            return;
+          }
+
           const nextIncrement = autoplayInvertDirection ? -1 : +1;
 
           let nextIndex = (paginationIndex + nextIncrement) % _data.length;

--- a/src/components/SwiperFlatList/__snapshots__/test.js.snap
+++ b/src/components/SwiperFlatList/__snapshots__/test.js.snap
@@ -191,3 +191,56 @@ exports[`swiper flatlist renders correctly 1`] = `
   </View>
 </RCTScrollView>
 `;
+
+exports[`swiper flatlist renders empty data correctly 1`] = `
+<RCTScrollView
+  data={Array []}
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={true}
+  initialNumToRender={1}
+  initialScrollIndex={0}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  onScrollToIndexFailed={[Function]}
+  onViewableItemsChanged={[Function]}
+  pagingEnabled={true}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEnabled={true}
+  scrollEventThrottle={50}
+  showsHorizontalScrollIndicator={false}
+  showsVerticalScrollIndicator={false}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfig={
+    Object {
+      "itemVisiblePercentThreshold": 60,
+      "minimumViewTime": 200,
+    }
+  }
+  viewabilityConfigCallbackPairs={
+    Array [
+      Object {
+        "onViewableItemsChanged": [Function],
+        "viewabilityConfig": Object {
+          "itemVisiblePercentThreshold": 60,
+          "minimumViewTime": 200,
+        },
+      },
+    ]
+  }
+  windowSize={21}
+>
+  <View />
+</RCTScrollView>
+`;

--- a/src/components/SwiperFlatList/test.js
+++ b/src/components/SwiperFlatList/test.js
@@ -14,6 +14,12 @@ describe('swiper flatlist', () => {
     );
     expect(toJSON()).toMatchSnapshot();
   });
+  it('renders empty data correctly', () => {
+    const { toJSON } = render(
+      <SwiperFlatList renderItem={({ item }) => <Image source={item.thumbnail} />} data={[]} />,
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
   it('renders children', () => {
     const { toJSON } = render(
       <SwiperFlatList>


### PR DESCRIPTION
while using reload, the data object may be empty (length == 0).  This can cause an exception if autoplay is set to true.  This fix checks for 0 length data and does not call scrollToIndex