### PR TITLE
Unused React import causes error in TSLint

### DIFF
--- a/src/components/SwiperFlatList/SwiperFlatList.web.ts
+++ b/src/components/SwiperFlatList/SwiperFlatList.web.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import React from 'react';
 const { SwiperFlatList: SwiperFlatListBase } = require('./SwiperFlatList.tsx');
 
 try {


### PR DESCRIPTION
An unused React import causes an error when imported into a project that uses TSLint. There's an ESLint ignore, but it doesn't prevent the issue for TSLint. 