### PR TITLE
fix : Modify _onViewableItemsChanged function

### DIFF
--- a/src/components/SwiperFlatList/SwiperFlatList.tsx
+++ b/src/components/SwiperFlatList/SwiperFlatList.tsx
@@ -206,13 +206,14 @@ export const SwiperFlatList = React.forwardRef(
     >(
       () => (params) => {
         const { changed } = params;
-        const newItem = changed?.[FIRST_INDEX];
-        if (newItem !== undefined) {
-          const nextIndex = newItem.index as number;
-          if (newItem.isViewable) {
-            setCurrentIndexes((prevState) => ({ ...prevState, index: nextIndex }));
-          } else {
-            setCurrentIndexes((prevState) => ({ ...prevState, prevIndex: nextIndex }));
+        for (const newItem of changed) {
+          if (newItem !== undefined) {
+            const nextIndex = newItem.index as number;
+            if (newItem.isViewable) {
+              setCurrentIndexes((prevState) => ({ ...prevState, index: nextIndex }));
+            } else {
+              setCurrentIndexes((prevState) => ({ ...prevState, prevIndex: nextIndex }));
+            }
           }
         }
         onViewableItemsChanged?.(params);


### PR DESCRIPTION
When swiping quickly, the `index` value received from `onChangeIndex` may be different from the `index` value displayed on the screen.

I upload a video when the issue occurs.

https://github.com/user-attachments/assets/5dd4a76d-2ae5-421d-bbe3-901d326743b1