### PR TITLE
Update Bitrise CI to use latest Xcode 26.0.x stack

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -118,4 +118,4 @@ trigger_map:
     pull_request_target_branch: master
 meta:
   bitrise.io:
-    stack: osx-xcode-14.3.x-ventura
+    stack: osx-xcode-26.0.x

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,21 +9,19 @@ workflows:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@8: {}
       - cache-pull@2: {}
-      - avd-manager@1:
+      - avd-manager@2:
           inputs:
             - tag: default
             - profile: Nexus 5X
             - emulator_id: Nexus_5X_API_27
             - api_level: '27'
-      - yarn@0:
+      - yarn@2:
           inputs:
             - workdir: example
-            - cache_local_deps: 'yes'
             - command: install
-      - npm@1:
+      - npm@3:
           inputs:
             - command: install -g detox-cli
-            - cache_local_deps: 'true'
             - workdir: example
       - script@1:
           inputs:
@@ -50,17 +48,15 @@ workflows:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@8: {}
       - cache-pull@2: {}
-      - yarn@0:
+      - yarn@2:
           inputs:
             - workdir: example
-            - cache_local_deps: 'yes'
             - command: install
-      - npm@1:
+      - npm@3:
           inputs:
             - command: install -g detox-cli
-            - cache_local_deps: 'true'
             - workdir: example
-      - cocoapods-install@2:
+      - cocoapods-install@3:
           inputs:
             - source_root_path: '$BITRISE_SOURCE_DIR/example/ios'
       - script@1:


### PR DESCRIPTION
The previous stack (osx-xcode-14.3.x-ventura) has been removed by Bitrise.
Update to the latest stable Xcode 26.0.x stack.

https://claude.ai/code/session_01QyNPVu5eKDz1KCfpvh6Q2L