### PR TITLE
Fix yarn install in GitHub Actions by enabling corepack

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,12 +14,18 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js 24.x
+    - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
-        node-version: 24.x
+        node-version: ${{ matrix.node-version }}
+    - name: Enable Corepack
+      run: corepack enable
     - run: yarn install
     - run: yarn tsc
     - run: yarn lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,8 @@ yarn jest --updateSnapshot
 ### GitHub Actions (`.github/workflows/node.js.yml`)
 - Triggers on push to `master` and PRs targeting `master`
 - Matrix: Node 20.x and 22.x
-- Steps: `yarn install` → `yarn tsc` → `yarn lint` → `yarn jest`
+- Enables corepack for Yarn 3 (Berry) support
+- Steps: `corepack enable` → `yarn install` → `yarn tsc` → `yarn lint` → `yarn jest`
 
 ### Pre-commit hook
 - Configured via `pre-commit` package in package.json


### PR DESCRIPTION
Yarn 3 (Berry) requires corepack to be enabled so that the packageManager field in package.json is respected. Without it, the system Yarn Classic (1.x) is used, which cannot parse the Yarn 3 lockfile format.

Also restores the Node.js version matrix (20.x, 22.x) for broader test coverage across LTS versions.

https://claude.ai/code/session_01WLB7148yUee86GdAebStHj