### PR TITLE
Migrate Bitrise from deprecated branch-based caching to key-based cac…

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,7 +8,7 @@ workflows:
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@8: {}
-      - cache-pull@2: {}
+      - restore-npm-cache@1: {}
       - avd-manager@2:
           inputs:
             - tag: default
@@ -30,7 +30,7 @@ workflows:
                 log\nset -x\n      \n# we are building a release device configuration\nyarn
                 detox build --configuration android.emu.release"
           title: Detox Build
-      - cache-push@2: {}
+      - save-npm-cache@1: {}
       - wait-for-android-emulator@1: {}
       - script@1:
           inputs:
@@ -47,7 +47,8 @@ workflows:
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@8: {}
-      - cache-pull@2: {}
+      - restore-npm-cache@1: {}
+      - restore-cocoapods-cache@1: {}
       - yarn@2:
           inputs:
             - workdir: example
@@ -80,9 +81,8 @@ workflows:
                 log\nset -x\n   \n# we are testing a release device configuration\nyarn
                 detox test --configuration ios.sim.release --cleanup"
           title: Detox Test
-      - cache-push@2:
-          inputs:
-            - cache_paths: ''
+      - save-npm-cache@1: {}
+      - save-cocoapods-cache@1: {}
       - deploy-to-bitrise-io@2:
           inputs:
             - deploy_path: example


### PR DESCRIPTION
…hing

Replace deprecated cache-pull@2 and cache-push@2 steps (removal date 2025-04-11) with the recommended key-based caching alternatives:

- android workflow: restore-npm-cache@1 / save-npm-cache@1
- primary workflow: restore-npm-cache@1 + restore-cocoapods-cache@1 / save-npm-cache@1 + save-cocoapods-cache@1

The dedicated caching steps automatically configure cache keys and paths, requiring no additional configuration.

https://claude.ai/code/session_01YJLZcp9TNGeE8mkZueZUcZ