### PR TITLE
ci: use only Node.js 24 in GitHub Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,18 +12,14 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [20.x, 22.x]
-
     steps:
     - uses: actions/checkout@v4
     - name: Install pnpm
       uses: pnpm/action-setup@v4
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 24.x
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 24.x
         cache: 'pnpm'
     - run: pnpm install
     - run: pnpm tsc


### PR DESCRIPTION
Replace the Node 20.x/22.x matrix with a single Node.js 24.x target.

https://claude.ai/code/session_01G4PnXbfvKUTnQhVbJA1wcw