### PR TITLE
Fix iOS pod install failure by hoisting pnpm dependencies

### DIFF
--- a/example/.npmrc
+++ b/example/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted


### PR DESCRIPTION
Add .npmrc with node-linker=hoisted in the example/ directory so that pnpm installs dependencies in a flat node_modules structure. This is required because React Native's CocoaPods integration and Expo's autolinking scripts expect to resolve packages like expo-modules-autolinking via standard Node.js module resolution, which fails under pnpm's default strict symlink layout.

https://claude.ai/code/session_01F6dVLQSCFtvczSipghMA9A