### PR TITLE
Add expo prebuild step for iOS in Bitrise CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -23,6 +23,15 @@ workflows:
                 set -x
                 npm install -g pnpm
                 pnpm install
+      - script@1:
+          title: Expo Prebuild iOS
+          inputs:
+            - working_dir: example
+            - content: |-
+                #!/usr/bin/env bash
+                set -e
+                set -x
+                pnpm expo prebuild --platform ios --clean
       - npm@3:
           inputs:
             - command: install -g detox-cli


### PR DESCRIPTION
Run `expo prebuild --platform ios --clean` after installing dependencies and before CocoaPods install to generate the native iOS project folder from the Expo-managed example app.

https://claude.ai/code/session_016YgzHVKAPT5f6yEALTRuRv