### PR TITLE
Fix Detox framework cache error by rebuilding cache before build

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -47,6 +47,16 @@ workflows:
                 tap wix/brew\nbrew install applesimutils"
           title: Detox Install
       - script@1:
+          title: Detox Build Framework Cache
+          inputs:
+            - working_dir: example
+            - content: |-
+                #!/usr/bin/env bash
+                set -e
+                set -x
+                detox clean-framework-cache
+                detox build-framework-cache
+      - script@1:
           inputs:
             - working_dir: example
             - content: "#!/usr/bin/env bash\n# fail if any commands fails\nset -e\n# debug


### PR DESCRIPTION
Add a "Detox Build Framework Cache" step to the Bitrise CI workflow that runs `detox clean-framework-cache && detox build-framework-cache` before the app build. This ensures the Detox.framework binary is compiled for the current Xcode version on the CI machine, fixing the DetoxRuntimeError about a missing framework.

https://claude.ai/code/session_01F9dn58NdcHexYJmnc66hMM