### PR TITLE
Cache Detox build derived data in Bitrise CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,6 +39,12 @@ workflows:
       - cocoapods-install@3:
           inputs:
             - source_root_path: '$BITRISE_SOURCE_DIR/example/ios'
+      - restore-cache@1:
+          title: Restore Detox Build Cache
+          inputs:
+            - key: |-
+                detox-build-{{ checksum "example/ios/Podfile.lock" }}-{{ checksum "example/app.json" }}
+                detox-build-
       - script@1:
           inputs:
             - working_dir: example
@@ -63,6 +69,12 @@ workflows:
                 log\nset -x\n      \n# we are building a release device configuration\npnpm
                 detox build --configuration ios.sim.release"
           title: Detox Build
+      - save-cache@1:
+          title: Save Detox Build Cache
+          inputs:
+            - key: detox-build-{{ checksum "example/ios/Podfile.lock" }}-{{ checksum "example/app.json" }}
+            - paths: example/ios/build
+            - is_key_unique: "true"
       - script@1:
           inputs:
             - working_dir: example


### PR DESCRIPTION
Add restore-cache and save-cache steps to cache the xcodebuild derived data directory (example/ios/build/) between CI runs. The cache key is based on Podfile.lock and app.json checksums, with a prefix fallback for partial cache matches. This enables incremental xcodebuild, which should significantly reduce the Detox build step time on cache hits.

https://claude.ai/code/session_01LRLatsmhLdQQgrwnBtJUfr